### PR TITLE
Fixed Seg Fault When Calling mbl_mw_datasignal_subscribe

### DIFF
--- a/examples/battery.py
+++ b/examples/battery.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import time
-from ctypes import cast, POINTER, c_uint
+from ctypes import cast, POINTER, c_uint, c_long
 from pymetawear.client import discover_devices, MetaWearClient, libmetawear
 from pymetawear.mbientlab.metawear.core import DataTypeId, BatteryState, FnDataPtr
 
@@ -41,6 +41,8 @@ def battery_callback(data):
 _battery_callback = FnDataPtr(battery_callback)
 
 print("Getting battery state data signal...")
+# Use long to hold pointer address
+libmetawear.mbl_mw_settings_get_battery_state_data_signal.restype= c_long
 battery_signal = libmetawear.mbl_mw_settings_get_battery_state_data_signal(c.board)
 print(type(battery_signal), battery_signal)
 
@@ -48,6 +50,8 @@ print("Subscribing to battery state...")
 libmetawear.mbl_mw_datasignal_subscribe(battery_signal, _battery_callback)
 print("Waiting for update...")
 
+print("Reading battery state...")
+libmetawear.mbl_mw_settings_read_battery_state(c.board)
 
 time.sleep(5.0)
 


### PR DESCRIPTION
On x64, pointers are 8 bytes and in this case, the battery signal address required all 8 bytes.  By default, the function objects return values as an int so we need to set the `restype` property to be c_long to hold the entire address.

In the old code, the int return type could not hold the entire address.  When it came time to call `mbl_mw_datasignal_subscribe`, only the first 4 bytes of the full address would be passed into the function resulting in a segmentation fault.