### PR TITLE
Fixed Typecasting Error For Calling mbl_mw_datasignal_subscribe

### DIFF
--- a/examples/battery.py
+++ b/examples/battery.py
@@ -47,7 +47,7 @@ battery_signal = libmetawear.mbl_mw_settings_get_battery_state_data_signal(c.boa
 print(type(battery_signal), battery_signal)
 
 print("Subscribing to battery state...")
-libmetawear.mbl_mw_datasignal_subscribe(battery_signal, _battery_callback)
+libmetawear.mbl_mw_datasignal_subscribe(c_long(battery_signal), _battery_callback)
 print("Waiting for update...")
 
 print("Reading battery state...")


### PR DESCRIPTION
Forgot that the function parameters are also treated as integers by default unless otherwise specified by setting `argtypes` parameter as outlined on the [ctypes page](https://docs.python.org/2/library/ctypes.html#specifying-the-required-argument-types-function-prototypes).