### PR TITLE
Fix Haptic module

### DIFF
--- a/pymetawear/modules/haptic.py
+++ b/pymetawear/modules/haptic.py
@@ -63,6 +63,7 @@ class HapticModule(PyMetaWearModule):
 
         """
         libmetawear.mbl_mw_haptic_start_motor(
+            self.board,
             c_float(float(duty_cycle_per)),
             c_uint16(int(pulse_width_ms)))
 
@@ -73,4 +74,5 @@ class HapticModule(PyMetaWearModule):
 
         """
         libmetawear.mbl_mw_haptic_start_buzzer(
+            self.board,
             c_uint16(int(pulse_width_ms)))


### PR DESCRIPTION
Add missing `self.board` argument to `libmetawear.mbl_mw_haptic_` calls