### PR TITLE
Implement calibration state notifications

### DIFF
--- a/pymetawear/modules/base.py
+++ b/pymetawear/modules/base.py
@@ -25,7 +25,7 @@ from pymetawear import libmetawear
 from pymetawear.exceptions import PyMetaWearException, PyMetaWearDownloadTimeout
 from mbientlab.metawear.cbindings import FnVoid_VoidP_DataP,  \
     DataTypeId, CartesianFloat, BatteryState, Tcs34725ColorAdc, EulerAngles, \
-    Quaternion, CorrectedCartesianFloat, FnVoid_VoidP_VoidP, \
+    CalibrationState, Quaternion, CorrectedCartesianFloat, FnVoid_VoidP_VoidP, \
     LogDownloadHandler, FnVoid_VoidP_UInt_UInt, \
     FnVoid_VoidP_UByte_Long_UByteP_UByte
 
@@ -363,7 +363,9 @@ DATA_HANDLERS = {
     DataTypeId.QUATERNION: lambda x: cast(
         x.contents.value, POINTER(Quaternion)).contents,
     DataTypeId.CORRECTED_CARTESIAN_FLOAT: lambda x: cast(
-        x.contents.value, POINTER(CorrectedCartesianFloat)).contents
+        x.contents.value, POINTER(CorrectedCartesianFloat)).contents,
+    DataTypeId.CALIBRATION_STATE: lambda x: cast(
+        x.contents.value, POINTER(CalibrationState)).contents,
 }
 
 

--- a/pymetawear/modules/sensorfusion.py
+++ b/pymetawear/modules/sensorfusion.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import warnings
 import logging
 from threading import Event
 
@@ -82,6 +83,7 @@ class SensorFusionModule(PyMetaWearLoggingModule):
         }
 
         self._callbacks = {}
+        self._calibration_state_callback = None
 
     def __str__(self):
         return "{0}".format(self.module_name)
@@ -218,7 +220,7 @@ class SensorFusionModule(PyMetaWearLoggingModule):
         this method.
 
         """
-        if self.calibration_state_callback is None:
+        if self._calibration_state_callback is None:
             warnings.warn("No calibration state callback is registered!",
                           RuntimeWarning)
         libmetawear.mbl_mw_datasignal_read(self.calibration_state_data_signal)
@@ -300,7 +302,7 @@ class SensorFusionModule(PyMetaWearLoggingModule):
         enable = False in [x is None for x in callback_data_source_map.values()]
         log.debug("Enable: %s" % enable)
 
-        self.calibration_state_callback = calibration_state_callback
+        self._calibration_state_callback = calibration_state_callback
 
         if not enable:
             self.stop()


### PR DESCRIPTION
I was unsure whether calibration state is notified  when changed, so I implemented `read_calibration_state()` as well, i.e. analogous to e.g. `read_temperature()`