### PR TITLE
Use metawear dependencies >=0.5.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 
 [packages]
 
-metawear = "==0.5.0"
+metawear = ">=0.5.0"
 tqdm = "*"
 
 

--- a/pymetawear/version.py
+++ b/pymetawear/version.py
@@ -14,5 +14,5 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-__version__ = '0.11.1'
+__version__ = '0.11.2'
 version = __version__  # backwards compatibility name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-metawear==0.5.0
+metawear>=0.5.0
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ AUTHOR = 'Henrik Blidh'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'metawear==0.5.0',
+    'metawear>=0.5.0',
     'tqdm',
 ]
 


### PR DESCRIPTION
So far, I have not experienced any compatibility issues when bumping the metawear version up to 0.7.0.